### PR TITLE
Add .git/ to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+.git
 node_modules
 dist


### PR DESCRIPTION
Copying the entire directory conents during a Docker build seems to break the build when trying to copy the .git/ subdirectory.

In general, there is no reason to copy over this directory when building.
